### PR TITLE
Add API usage option to telegram-phone-number-checker with FastAPI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,48 @@ For each phone number, you can expect the following possible responses:
 3. 'ERROR: no response, the user does not exist or has blocked contact adding.': There can be several reasons for this response. Either the phone number has not been used to create a Telegram account. Or: The phone number is connected to a Telegram account but the user has restricted the option to find him/her via the phone number.
 4. Or: another error occurred.
 
+## API Usage
+
+You can also expose this tool as an API using FastAPI. To start the API, use the following command:
+
+```bash
+telegram-phone-number-checker --use-api
+```
+
+By default, the API will run on port 8000, but you can specify a different port:
+
+```bash
+telegram-phone-number-checker --use-api --api-port 8080
+```
+
+### API Endpoints
+
+```curl
+GET /get_user_info?check_number=+1234567890
+```
+
+Response body:
+
+```json
+{
+  "id": 123456789,
+  "username": "example_user",
+  "usernames": null,
+  "first_name": "John",
+  "last_name": "Doe",
+  "fake": false,
+  "verified": false,
+  "premium": false,
+  "mutual_contact": true,
+  "bot": false,
+  "bot_chat_history": false,
+  "restricted": false,
+  "restriction_reason": null,
+  "user_was_online": "2024-10-07 12:34:56 UTC",
+  "phone": "+1234567890"
+}
+```
+
 
 ## Development 
 This section describes how to install the project in order to run it locally, for example if you want to build new features.

--- a/telegram_phone_number_checker/main.py
+++ b/telegram_phone_number_checker/main.py
@@ -41,9 +41,9 @@ app = FastAPI(
 )
 
 @app.get("/get_user_info")
-async def get_user_info(api_id: str, api_hash: str, phone_number: str, check_number: str):
+async def get_user_info(check_number: str):
     try:
-        client = await login(api_id, api_hash, phone_number)
+        client = app.state.client
         result = await get_names(client, check_number)
         await client.disconnect()
         if "error" in result:

--- a/telegram_phone_number_checker/main.py
+++ b/telegram_phone_number_checker/main.py
@@ -241,26 +241,26 @@ def show_results(output: str, res: dict) -> None:
     "--api-id",
     help="Your Telegram app api_id",
     type=str,
+    prompt="Enter your Telegram App app_id",
     envvar="API_ID",
-    show_envvar=True,
-    required=False
+    show_envvar=True
 )
 @click.option(
     "--api-hash",
     help="Your Telegram app api_hash",
     type=str,
+    prompt="Enter your Telegram App api_hash",
     hide_input=True,
     envvar="API_HASH",
-    show_envvar=True,
-    required=False
+    show_envvar=True
 )
 @click.option(
     "--api-phone-number",
     help="Your phone number",
     type=str,
+    prompt="Enter the number associated with your Telegram account",
     envvar="PHONE_NUMBER",
-    show_envvar=True,
-    required=False
+    show_envvar=True
 )
 @click.option(
     "--output",
@@ -338,17 +338,14 @@ def main_entrypoint(
 
     """
     if use_api:
+        app.state.api_id = api_id
+        app.state.api_hash = api_hash
+        app.state.phone_number = api_phone_number
         logging.info(f"Starting FastAPI server on port {api_port}...")
         uvicorn.run(app, host="0.0.0.0", port=api_port)
         ctx.exit()
     if not phone_numbers:
         phone_numbers = click.prompt("Enter the phone numbers to check, separated by commas")
-    if not api_id:
-        api_id = click.prompt("Enter your Telegram App api_id")
-    if not api_hash:
-        api_hash = click.prompt("Enter your Telegram App api_hash", hide_input=True)
-    if not api_phone_number:
-        api_phone_number = click.prompt("Enter the number associated with your Telegram account")
     asyncio.run(
         run_program(
             phone_numbers,


### PR DESCRIPTION
Hi! I'm excited to contribute to the **telegram-phone-number-checker** project and to collaborate with the **Bellingcat** team, whose projects I really admire! 💻🚀

In this PR, I've added the option to run the tool as an API using **FastAPI**. This change allows users to check phone numbers associated with Telegram via an API interface, in addition to the traditional CLI usage.

#### Changes made:
- Implemented **FastAPI** with a `lifespan` method to manage the Telegram session (connect on startup and disconnect on shutdown).
- Added a `--use-api` option to start the FastAPI server.
- Updated the README with a new section explaining API usage, including details on the `/get_user_info` endpoint.
- The phone number validation via CLI remains unchanged and fully functional.

#### Testing:
I performed tests to ensure the tool works seamlessly both via CLI and API. I'll include a screenshot below showcasing the API test in action.

I'm really excited to see this feature integrated and hope it helps extend the tool's usability! 😄

![test](https://github.com/user-attachments/assets/d09e5dd2-52ce-4764-bb73-dadf3afbe5be)

Closes https://github.com/bellingcat/telegram-phone-number-checker/issues/7.
