### PR TITLE
feat: add username search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ PHONE_NUMBER=
 If you don't create this file, you can also provide these 3 values when calling the tool, or even be prompted for them interactively.
 
 ## Usage
+
+### Search by phone number
 The tool accepts a comma-separated list of phone numbers to check, you can pass this when you call the tool, or interactively.
 
 See the examples below:
@@ -62,14 +64,32 @@ telegram-phone-number-checker
 telegram-phone-number-checker --api-id YOUR_API_KEY --api-hash YOUR_API_HASH --api-phone-number YOUR_PHONE_NUMBER --phone-numbers +1234567890
 ```
 
+### Search by Username
+You can also search by Telegram username(s):
+
+```bash
+# single username
+telegram-phone-number-checker --usernames john
+
+# multiple usernames
+telegram-phone-number-checker --usernames john,jane
+
+# combine phone numbers and usernames
+telegram-phone-number-checker --phone-numbers +1234567890 --usernames johndoe
+
+# with profile photo download
+telegram-phone-number-checker --usernames johndoe --download-profile-photos
+```
+
 The result will be written to the console but also written as JSON to a `results.json` file, you can write it to another file by adding `--output your_filename.json` to the command.
 
-For each phone number, you can expect the following possible responses:
+For each phone number or username, you can expect the following possible responses:
 
 1. If available, you will receive the Telegram Username, Name, and ID that are connected with this number.
 2. 'no username detected'. This means that it looks like the number was used to create a Telegram account but the user did not choose a Telegram Username. It is optional to create a Username on Telegram.
 3. 'ERROR: no response, the user does not exist or has blocked contact adding.': There can be several reasons for this response. Either the phone number has not been used to create a Telegram account. Or: The phone number is connected to a Telegram account but the user has restricted the option to find him/her via the phone number.
-4. Or: another error occurred.
+4. For username searches: The username may not exist, or it may belong to a channel/group rather than a user account. In the latter case, an output such as '@group_name is a channel or supergroup ('Group'), not a user account. This tool is for searching user accounts only'
+5. Or: another error occurred.
 
 
 ## Development 


### PR DESCRIPTION
## Add username search functionality

### Summary
Adds the ability to search for Telegram users by username (e.g., `@username` or `username`) in addition to the existing phone number search. 

### Changes Made
- Added `--usernames` / `-u` CLI option
- Implemented `get_user_by_username()` using Telegram's `get_entity()` API
- Created `validate_usernames()` to process comma-separated username lists
- Updated `run_program()` to handle both phone numbers and usernames (separately or combined)
- Enhanced interactive mode to prompt for search type (phone/username)
- Added validation to distinguish between users, channels, and groups (only searches user accounts)
- Fixed `usernames` field serialization bug (converted Username objects to list of strings)
- Updated README.md with usage examples

### Usage Examples
```bash
# Single username
telegram-phone-number-checker --usernames someuser

# Multiple usernames
telegram-phone-number-checker --usernames user1,user2,user3

# Combine with phone numbers
telegram-phone-number-checker --phone-numbers +123456789 --usernames someuser

# Interactive mode
telegram-phone-number-checker
# Then choose 'u' for username search